### PR TITLE
커버리지 리포트 생성을 위한 Actions 설정 추가

### DIFF
--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -1,4 +1,4 @@
-name: Code coverage report
+name: Report code coverage
 
 on:
   push:
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Generate code coverage report
+      - name: Generate report
         run: ./gradlew clean test jacocoTestReport
       - uses: codecov/codecov-action@v1
         name: Upload report

--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -3,7 +3,7 @@ name: Code coverage report
 on:
   push:
     branches:
-      - master
+      - develop
 
 jobs:
 

--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -1,0 +1,22 @@
+name: Code coverage report
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Generate code coverage report
+        run: ./gradlew clean test jacocoTestReport
+      - uses: codecov/codecov-action@v1
+        name: Upload report
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./build/reports/jacoco/report.xml
+          name: codecov-umbrella
+          fail_ci_if_error: true

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,9 @@
 plugins {
-	id 'org.springframework.boot' version '2.2.1.RELEASE'
-	id 'io.spring.dependency-management' version '1.0.8.RELEASE'
-	id "org.asciidoctor.convert" version "1.5.10"
-	id 'java'
+    id 'org.springframework.boot' version '2.2.1.RELEASE'
+    id 'io.spring.dependency-management' version '1.0.8.RELEASE'
+    id "org.asciidoctor.convert" version "1.5.10"
+    id 'java'
+    id 'jacoco'
 }
 
 group = 'com.woowacourse'
@@ -10,12 +11,12 @@ version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '1.8'
 
 ext {
-	snippetsDir = file('build/generated-snippets')
+    snippetsDir = file('build/generated-snippets')
 }
 
 asciidoctor {
-	inputs.dir snippetsDir
-	dependsOn	 test
+    inputs.dir snippetsDir
+    dependsOn test
 }
 
 bootJar {
@@ -26,30 +27,30 @@ bootJar {
 }
 
 test {
-	useJUnitPlatform()
-	outputs.dir snippetsDir
+    useJUnitPlatform()
+    outputs.dir snippetsDir
 }
 
 task copyDocument(type: Copy) {
-	dependsOn asciidoctor
+    dependsOn asciidoctor
 
-	from file("build/asciidoc/html5/")
-	into file("src/main/resources/static/docs")
+    from file("build/asciidoc/html5/")
+    into file("src/main/resources/static/docs")
 }
 
 build {
-	dependsOn copyDocument
+    dependsOn copyDocument
 }
 
 configurations {
-	developmentOnly
-	runtimeClasspath {
-		extendsFrom developmentOnly
-	}
+    developmentOnly
+    runtimeClasspath {
+        extendsFrom developmentOnly
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
@@ -69,4 +70,13 @@ dependencies {
 	testImplementation 'io.projectreactor:reactor-test'
 	testImplementation 'org.mockito:mockito-junit-jupiter:3.1.0'
 	implementation 'org.modelmapper:modelmapper:2.3.0'
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled true
+        xml.destination file("${buildDir}/reports/jacoco/report.xml")
+        csv.enabled false
+        html.enabled false
+    }
 }


### PR DESCRIPTION
`develop` 브랜치에 푸시될 때마다 코드 커버리지 리포트를 생성하고 별도 플랫폼에 업로드하는 Actions 설정을 추가합니다.